### PR TITLE
refactor dna validation and hashing

### DIFF
--- a/src/main/java/com/schambeck/dna/web/service/DnaServiceImpl.java
+++ b/src/main/java/com/schambeck/dna/web/service/DnaServiceImpl.java
@@ -12,8 +12,10 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 @Service
 public class DnaServiceImpl implements DnaService {
@@ -57,14 +59,11 @@ public class DnaServiceImpl implements DnaService {
     @Override
     public StatsDto stats() {
         List<QueryStatsDto> list = repository.stats();
+        Map<Boolean, Long> map = list.stream()
+                .collect(Collectors.toMap(QueryStatsDto::isMutant, QueryStatsDto::getCount));
         StatsDto stats = new StatsDto();
-        for (QueryStatsDto query : list) {
-            if (query.isMutant()) {
-                stats.setCountMutantDna(query.getCount());
-            } else {
-                stats.setCountHumanDna(query.getCount());
-            }
-        }
+        stats.setCountMutantDna(map.getOrDefault(true, 0L));
+        stats.setCountHumanDna(map.getOrDefault(false, 0L));
         return stats;
     }
 

--- a/src/main/java/com/schambeck/dna/web/service/MutantServiceImpl.java
+++ b/src/main/java/com/schambeck/dna/web/service/MutantServiceImpl.java
@@ -5,8 +5,6 @@ import com.schambeck.dna.web.exception.NotSquareException;
 import com.schambeck.dna.web.search.TextSearch;
 import org.springframework.stereotype.Service;
 
-import java.util.Arrays;
-
 import static java.lang.String.format;
 
 @Service
@@ -29,9 +27,10 @@ public class MutantServiceImpl implements MutantService {
 
     private void validateSquare(String[] dna) {
         int rows = dna.length;
-        boolean anyMatch = Arrays.stream(dna).anyMatch(p -> p.length() != rows);
-        if (anyMatch) {
-            throw new NotSquareException(format("DNA must be a square table %dx%d", rows, rows));
+        for (String row : dna) {
+            if (row.length() != rows) {
+                throw new NotSquareException(format("DNA must be a square table %dx%d", rows, rows));
+            }
         }
     }
 

--- a/src/main/java/com/schambeck/dna/web/util/HashUtil.java
+++ b/src/main/java/com/schambeck/dna/web/util/HashUtil.java
@@ -1,9 +1,6 @@
 package com.schambeck.dna.web.util;
 
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.io.ObjectOutputStream;
-import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 
@@ -14,9 +11,11 @@ public final class HashUtil {
     private static final String SHA_256 = "SHA-256";
     private static HashUtil INSTANCE;
     private final String algorithm;
+    private final MessageDigest digest;
 
     private HashUtil(String algorithm) {
         this.algorithm = algorithm;
+        this.digest = newDigest();
     }
 
     public static HashUtil getInstance() {
@@ -31,13 +30,12 @@ public final class HashUtil {
     }
 
     public String hash(String[] dna) {
-        ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        writeBytes(dna, baos);
-        return hash(baos.toByteArray());
+        String joined = String.join("", dna);
+        return hash(joined.getBytes(StandardCharsets.UTF_8));
     }
 
-    public String hash(byte[] bytes) {
-        MessageDigest digest = newDigest();
+    public synchronized String hash(byte[] bytes) {
+        digest.reset();
         digest.update(bytes);
         byte[] hash = digest.digest();
         return toHex(hash).toUpperCase();
@@ -60,15 +58,6 @@ public final class HashUtil {
             hexString.append(hex);
         }
         return hexString.toString();
-    }
-
-    void writeBytes(String[] dna, OutputStream baos) {
-        try (ObjectOutputStream oos = new ObjectOutputStream(baos)) {
-            oos.writeObject(dna);
-            oos.flush();
-        } catch (IOException e) {
-            throw new RuntimeException("Fail to convert string array to bytes");
-        }
     }
 
 }

--- a/src/test/java/com/schambeck/dna/web/util/HashUtilTest.java
+++ b/src/test/java/com/schambeck/dna/web/util/HashUtilTest.java
@@ -2,11 +2,7 @@ package com.schambeck.dna.web.util;
 
 import org.junit.jupiter.api.Test;
 
-import java.io.IOException;
-import java.io.OutputStream;
-
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class HashUtilTest {
 
@@ -14,32 +10,9 @@ class HashUtilTest {
     void createHash() {
         String[] dna = {"CTGAGA", "CTGAGC", "TATTGT", "AGAGGG", "CCCCTA", "TCACTG"};
         String actual = HashUtil.getInstance().hash(dna);
-        String expected = "87DDB4DC78AA028ECD0379B6EF0058435012B13F18D3CA0294ADFA1DC8F3BEED";
+        String expected = "2BED6CDF8E1818067352975757C3D39289C522B186A887FB6EB3EFB1CFB82287";
         assertEquals(expected, actual);
     }
 
-    @Test
-    void createHashIOException() {
-        String[] dna = {"CTGAGA", "CTGAGC", "TATTGT", "AGAGGG", "CCCCTA", "TCACTG"};
-        OutputStream os = new OutputStream() {
-            @Override
-            public void write(int b) throws IOException {
-                throw new IOException();
-            }
-        };
-        RuntimeException ex = assertThrows(RuntimeException.class, () -> HashUtil.getInstance().writeBytes(dna, os));
-        String expected = "Fail to convert string array to bytes";
-        String actual = ex.getMessage();
-        assertEquals(actual, expected);
-    }
-
-//    @Test
-//    void createHashInvalidAlgorithm() {
-//        String[] dna = {"CTGAGA", "CTGAGC", "TATTGT", "AGAGGG", "CCCCTA", "TCACTG"};
-//        RuntimeException ex = assertThrows(RuntimeException.class, () -> HashUtil.getInstance("INVALID").hash(dna));
-//        String expected = "Fail to create new MessageDigest of INVALID";
-//        String actual = ex.getMessage();
-//        assertEquals(actual, expected);
-//    }
 
 }


### PR DESCRIPTION
## Summary
- streamline square DNA validation without stream overhead
- reuse MessageDigest and simplify DNA hashing
- aggregate stats via map-based lookup

## Testing
- ⚠️ `./mvnw -q test` *(failed: Could not find or load main class org.apache.maven.wrapper.MavenWrapperMain)*

------
https://chatgpt.com/codex/tasks/task_e_68a30eaddcd4832dafdbf4f20ac62a05